### PR TITLE
Fix username reference on club page

### DIFF
--- a/tools/www-tpl/default-en/club.tpl
+++ b/tools/www-tpl/default-en/club.tpl
@@ -26,7 +26,7 @@ var andSoItBegins = (new Date()).getTime();
 
 <script type="text/javascript">
 document.habboLoggedIn = {{ session.loggedIn }};
-var habboName = "{{ playerDetails.username }}";
+var habboName = "{{ playerDetails.getName() }}";
 var ad_keywords = "";
 var habboReqPath = "{{ site.sitePath }}";
 var habboStaticFilePath = "{{ site.staticContentPath }}/web-gallery";
@@ -96,7 +96,7 @@ body { behavior: url({{ site.staticContentPath }}/web-gallery/js/csshover.htc); 
 			<li class="">
 				<a href="{{ site.sitePath }}/me">Home</a>			</li>
     		<li class="">
-				<a href="{{ site.sitePath }}/home/{{ playerDetails.username }}">My Page</a>    		</li>
+				<a href="{{ site.sitePath }}/home/{{ playerDetails.getName() }}">My Page</a>    		</li>
 			<li class="">
 				<a href="{{ site.sitePath }}/profile">Account Settings</a>			</li>
 				<li class="selected{% if gameConfig.getInteger('guides.group.id') == 0 %} last{% endif %}">


### PR DESCRIPTION
The 'club' page uses `{{ playerDetails.username }}`, which seems to be empty. I replaced it with `{{ placerDetails.getName() }}`, which was used in every other place.

<img width="846" alt="Screenshot 2022-11-13 at 14 11 08" src="https://user-images.githubusercontent.com/106544864/201523389-f188c270-5f99-40f0-8f10-860b3361f550.png">
