### PR TITLE
Fix for housekeeping stats

### DIFF
--- a/Havana-Web/src/main/java/org/alexdev/http/game/housekeeping/HousekeepingStats.java
+++ b/Havana-Web/src/main/java/org/alexdev/http/game/housekeeping/HousekeepingStats.java
@@ -16,4 +16,28 @@ public class HousekeepingStats {
         this.petCount = petCount;
         this.photoCount = photoCount;
     }
+
+    public int getUserCount() {
+        return userCount;
+    }
+
+    public int getInventoryItemsCount() {
+        return inventoryItemsCount;
+    }
+
+    public int getRoomItemCount() {
+        return roomItemCount;
+    }
+
+    public int getGroupCount() {
+        return groupCount;
+    }
+
+    public int getPetCount() {
+        return petCount;
+    }
+
+    public int getPhotoCount() {
+        return photoCount;
+    }
 }


### PR DESCRIPTION
The housekeeping statistics on the dashboard didn't load in because pebble (twig) couldn't access the private variables.
By adding public get methods for each variable, the stats all load in again.

Another possibility could be to refactor the class to a record, which would save up a few lines. (43 lines => 11 lines)
```java
package org.alexdev.http.game.housekeeping;

public record HousekeepingStats(
        int userCount,
        int inventoryItemsCount,
        int roomItemCount,
        int groupCount,
        int petCount,
        int photoCount
) {
}
```

Before:
<img width="484" alt="Screenshot 2022-11-13 at 22 22 34" src="https://user-images.githubusercontent.com/106544864/201545246-5bb9bc9a-fede-4406-9846-9df87f854e36.png">

After:
<img width="488" alt="Screenshot 2022-11-13 at 22 22 28" src="https://user-images.githubusercontent.com/106544864/201545245-ecfe7526-34fe-41be-ac8f-bde43365626f.png">
