### PR TITLE
Add user transaction log for buying Habbo Club

### DIFF
--- a/Havana-Server/src/main/java/org/alexdev/havana/game/club/ClubSubscription.java
+++ b/Havana-Server/src/main/java/org/alexdev/havana/game/club/ClubSubscription.java
@@ -80,7 +80,7 @@ public class ClubSubscription {
      * @param playerDetails the details of the player that subscribed
      * @param choice the subscription choice
      */
-    public static boolean subscribeClub(PlayerDetails playerDetails, int choice) {
+    public static boolean subscribeClub(PlayerDetails playerDetails, int choice) throws SQLException {
         var choiceData = getChoiceData(choice);
 
         int credits = choiceData.getKey();
@@ -123,6 +123,17 @@ public class ClubSubscription {
 
         PlayerDao.saveSubscription(playerDetails.getId(), playerDetails.getFirstClubSubscription(), playerDetails.getClubExpiration());
         CurrencyDao.decreaseCredits(playerDetails, credits);
+
+        TransactionDao.createTransaction(
+            playerDetails.getId(),
+            "0",
+            "0",
+            days,
+            "Habbo Club purchase",
+            credits,
+            0,
+            true
+        );
 
         return true;
     }

--- a/Havana-Web/src/main/java/org/alexdev/http/controllers/habblet/HabboClubHabblet.java
+++ b/Havana-Web/src/main/java/org/alexdev/http/controllers/habblet/HabboClubHabblet.java
@@ -13,6 +13,7 @@ import org.alexdev.havana.util.DateUtil;
 import org.alexdev.havana.util.config.GameConfiguration;
 import org.alexdev.http.util.RconUtil;
 
+import java.sql.SQLException;
 import java.util.HashMap;
 import java.util.concurrent.TimeUnit;
 
@@ -39,7 +40,7 @@ public class HabboClubHabblet {
         template.render();
     }
 
-    public static void subscribe(WebConnection webConnection) {
+    public static void subscribe(WebConnection webConnection) throws SQLException {
         if (!webConnection.session().getBoolean("authenticated")) {
             return;
         }


### PR DESCRIPTION
This pull request creates a user transaction when the user buys HC from the homepage.

1 potential issue is that there is no item_id to track. 
I used the value `"0"`, as this seems to be used for effects and films too.