### PR TITLE
Fix trade-ban to ban only on suspicious behavior

### DIFF
--- a/Havana-Server/src/main/java/org/alexdev/havana/game/player/PlayerDetails.java
+++ b/Havana-Server/src/main/java/org/alexdev/havana/game/player/PlayerDetails.java
@@ -538,4 +538,8 @@ public class PlayerDetails {
     public String getPreviousRespectDay() {
         return previousRespectDay;
     }
+
+    public String getIpAddress() {
+       return PlayerDao.getLatestIp(this.getId());
+    }
 }

--- a/Havana-Server/src/main/java/org/alexdev/havana/game/room/managers/RoomTradeManager.java
+++ b/Havana-Server/src/main/java/org/alexdev/havana/game/room/managers/RoomTradeManager.java
@@ -150,8 +150,8 @@ public class RoomTradeManager {
      * @param tradeBanned the person that is trade banned.
      */
     public static void addTradeBan(Player tradeBanned) {
-        tradeBanned.send(new ALERT("You have been trade banned for 7 days for suspicious activity. Do not give credits to other users.<br>Read for more info: https://classichabbo.com/articles/22-trade-banned"));
-        tradeBanned.getDetails().setTradeBanExpiration(DateUtil.getCurrentTimeSeconds() + TimeUnit.DAYS.toSeconds(7));
+        tradeBanned.send(new ALERT("You have been trade banned for 5 days for suspicious activity. Do not give credits to other users."));
+        tradeBanned.getDetails().setTradeBanExpiration(DateUtil.getCurrentTimeSeconds() + TimeUnit.DAYS.toSeconds(5));
         ItemDao.saveTradeBanExpire(tradeBanned.getDetails().getId(), tradeBanned.getDetails().getTradeBanExpiration());
     }
 

--- a/Havana-Server/src/main/java/org/alexdev/havana/messages/incoming/catalogue/GRPC.java
+++ b/Havana-Server/src/main/java/org/alexdev/havana/messages/incoming/catalogue/GRPC.java
@@ -147,13 +147,14 @@ public class GRPC implements MessageEvent {
                     return;
                 }
 
-                //if (item.getDefinition().hasBehaviour(ItemBehaviour.REDEEMABLE)) {
+                if (item.getDefinition().hasBehaviour(ItemBehaviour.REDEEMABLE)) {
                 if (!player.hasFuse(Fuseright.MUTE)
-                        && giftedUserDetails.getId() != player.getDetails().getId()) {
+                        && giftedUserDetails.getId() != player.getDetails().getId()
+                        && giftedUserDetails.getIpAddress().equals(player.getDetails().getIpAddress())) {
                     RoomTradeManager.addTradeBan(player);
                     return;
                 }
-                //}
+                }
             }
 
             String presentNote = reader.readString();

--- a/Havana-Server/src/main/java/org/alexdev/havana/messages/incoming/rooms/items/PLACESTUFF.java
+++ b/Havana-Server/src/main/java/org/alexdev/havana/messages/incoming/rooms/items/PLACESTUFF.java
@@ -4,8 +4,10 @@ import org.alexdev.havana.dao.mysql.ItemDao;
 import org.alexdev.havana.dao.mysql.TransactionDao;
 import org.alexdev.havana.game.fuserights.Fuseright;
 import org.alexdev.havana.game.item.Item;
+import org.alexdev.havana.game.item.ItemManager;
 import org.alexdev.havana.game.item.base.ItemBehaviour;
 import org.alexdev.havana.game.player.Player;
+import org.alexdev.havana.game.player.PlayerDetails;
 import org.alexdev.havana.game.player.PlayerManager;
 import org.alexdev.havana.game.room.Room;
 import org.alexdev.havana.game.room.managers.RoomTradeManager;
@@ -64,14 +66,17 @@ public class PLACESTUFF implements MessageEvent {
             }
         }
 
+        PlayerDetails ownerDetails = PlayerManager.getInstance().getPlayerData(room.getData().getOwnerId());
+
         // Giving credits to self on same IP is suspicious behaviour
-        //if (item.hasBehaviour(ItemBehaviour.REDEEMABLE) || ItemManager.getInstance().hasPresentBehaviour(item, ItemBehaviour.REDEEMABLE)) {
+        if (item.hasBehaviour(ItemBehaviour.REDEEMABLE) || ItemManager.getInstance().hasPresentBehaviour(item, ItemBehaviour.REDEEMABLE)) {
             if (!player.hasFuse(Fuseright.MUTE)
-                    && room.getData().getOwnerId() != player.getDetails().getId()) {
+                    && room.getData().getOwnerId() != player.getDetails().getId()
+                    && player.getDetails().getIpAddress().equals(ownerDetails.getIpAddress())) {
                 RoomTradeManager.addTradeBan(player);
                 return;
             }
-        //}
+        }
 
         var ownerData = PlayerManager.getInstance().getPlayerData(room.getData().getOwnerId());
 


### PR DESCRIPTION
Currently, when we send a furni to a player, we are automatically trade-banned. 
I restored a logical behavior to ban only when trying to cheat.