### PR TITLE
Add queen promotion in chess

### DIFF
--- a/Havana-Server/src/main/java/org/alexdev/havana/game/games/gamehalls/GameChess.java
+++ b/Havana-Server/src/main/java/org/alexdev/havana/game/games/gamehalls/GameChess.java
@@ -151,6 +151,10 @@ public class GameChess extends GamehallGame {
                 var moveList = MoveGenerator.generateLegalMoves(this.board);
                 isLegalMove = moveList.contains(move);//.stream().anyMatch(m -> m.getFrom() == fromSquare && m.getTo() == toSquare);
 
+                if (!isLegalMove && Board.isPromoRank(this.board.getSideToMove(), move)) { // if the move is not legal, check if pawn promotion is legal
+                    move = new Move(fromSquare, toSquare, Piece.make(this.board.getSideToMove(), PieceType.QUEEN));
+                    isLegalMove = moveList.contains(move);
+                }
             } catch (MoveGeneratorException e) { }
 
             if (isLegalMove) {


### PR DESCRIPTION
Adds promotion of pawn into queen. Still need to deal with the message logic. Fixes #27.