### PR TITLE
Patch several xss vulnerabilities

### DIFF
--- a/Havana-Web/src/main/java/org/alexdev/http/controllers/site/TagController.java
+++ b/Havana-Web/src/main/java/org/alexdev/http/controllers/site/TagController.java
@@ -115,7 +115,7 @@ public class TagController {
             boolean isValidTag = temporaryTag != null;
 
             if (isValidTag) {
-                tpl.set("tagSearchAdd", " <p id=\"tag-search-add\" class=\"clearfix\"><span style=\"float:left\">Tag yourself with:</span> <a id=\"tag-search-tag-add\" href=\"#\" class=\"new-button\" style=\"float:left\" onclick=\"TagHelper.addThisTagToMe('" + tag + "',false);return false;\"><b>" + tag + "</b><i></i></a></p>\n");
+                tpl.set("tagSearchAdd", tag);
             }
         }
 

--- a/tools/www-tpl/default-en/base/tag_search.tpl
+++ b/tools/www-tpl/default-en/base/tag_search.tpl
@@ -8,12 +8,20 @@
 			{% else %}
 				<p class="search-result-count">{{ pageId }} - {{ totalTagUsers|length }} / {{ totalCount }}</p>
 			{% endif %}
-			{{ tagSearchAdd }}
+			{% autoescape 'html' %}
+			{% if tagSearchAdd != "" %}
+			<p id="tag-search-add" class="clearfix">
+				<span style="float:left">Tag yourself with:</span>
+				<a id="tag-search-tag-add" href="#" class="new-button" style="float:left" onclick="TagHelper.addThisTagToMe('{{ tagSearchAdd | replace({"'": "\'"}) }}',false);return false;">
+					<b>{{ tagSearchAdd }}</b>
+					<i></i>
+				</a>
+			</p>
+			{% endif %}
 			<p class="search-result-divider"></p>
 
 			<table border="0" cellpadding="0" cellspacing="0" width="100%" class="search-result">
 				<tbody>
-				{% autoescape 'html' %}
 				{% set num = 0 %}
 				{% if tagList.size() > 0 %}
 				{% for habboTag in tagList %}
@@ -61,9 +69,9 @@
 				</tr>
 				{% endfor %}
 				{% endif %}
-				{% endautoescape %}
 				</tbody>
 			</table>
+			{% endautoescape %}
 			<p class="search-result-navigation">
 			{% if showFirst %}
 			<a href="{{ site.sitePath }}/tag/{{ tag }}?pageNumber={{ showFirstPage }}"><<</a>

--- a/tools/www-tpl/default-en/community.tpl
+++ b/tools/www-tpl/default-en/community.tpl
@@ -322,7 +322,9 @@ var discussionMoreDataHelper = new MoreDataHelper("discussions-toggle-more-data-
 						{% endif %}
 						
                         {{ site.siteName }} created on: {{ habbo.getCreatedAt() }}
+												{% autoescape 'html' %}
                             <p class="motto">{{ habbo.getMotto() }}</p>
+												{% endautoescape %}
                     </div>
                 </div>
                 <input type="hidden" id="active-habbo-url-{{ num }}" value="{{ site.sitePath }}/home/{{ habbo.getName() }}"/>

--- a/tools/www-tpl/default-en/groups/discussions/opentopicsettings.tpl
+++ b/tools/www-tpl/default-en/groups/discussions/opentopicsettings.tpl
@@ -4,7 +4,9 @@
 	    		<span class="topic-name-text" id="topic_name_text">Topic: (max 32 characters)</span>
 	    	</div>
 	    	<div class="topic-name-input">
+				{% autoescape 'html' %}
 	    		<input type="text" size="38" maxlength="32" name="topic_name" id="topic_name" onKeyUp="GroupUtils.validateGroupElements('topic_name', 32, 'myhabbo.topic.name.max.length.exceeded');" value="{{ topic.getTopicTitle() }}"/>
+				{% endautoescape %}
 			</div>
             <div id="topic-name-error"></div>
             <div id="topic_name_message_error" class="error"></div>

--- a/tools/www-tpl/default-en/groups/habblet/group_settings.tpl
+++ b/tools/www-tpl/default-en/groups/habblet/group_settings.tpl
@@ -9,7 +9,9 @@
         <div id="group-name-area">
           <div id="group_name_message_error" class="error"></div>
           <label for="group_name" id="group_name_text">Edit group name:</label>
+          {% autoescape 'html' %}
           <input type="text" name="group_name" id="group_name" onKeyUp="GroupUtils.validateGroupElements('group_name', 30, 'Maximum Group name length reached');" value="{{ group.getName }}"/><br />
+          {% endautoescape %}
         </div>
 
         <div id="group-url-area">
@@ -135,6 +137,7 @@
         <ul>
           <li><input type="radio" name="roomId" value="" {% if group.getRoomId() == 0 %}checked="checked" {% endif %}/><div>No room</div></li>
 
+    {% autoescape 'html' %}
 		{% set num = 0 %}
 		{% for room in rooms %}
 			{% if num % 2 == 0 %}
@@ -152,6 +155,7 @@
           </li>
 		  {% set num = num + 1 %}
 		  {% endfor %}
+      {% endautoescape %}
         </ul>
       </div>
     </div>

--- a/tools/www-tpl/default-en/homes/editor/search.tpl
+++ b/tools/www-tpl/default-en/homes/editor/search.tpl
@@ -1,6 +1,7 @@
 <ul>
 	<li>Click on link below to insert it into the document</li>
 
+	{% autoescape 'html' %}
 	{% for kvp in querySearch %}
 		{% set key = kvp.getKey() %}
 		{% set value = kvp.getValue() %}
@@ -9,6 +10,7 @@
     	value="{{ value }}" title="{{ key }}">{{ key }}</a></li>
 
 	{% endfor %}
+	{% endautoescape %}
 
 
 </ul>

--- a/tools/www-tpl/default-en/homes/widget/groups_widget.tpl
+++ b/tools/www-tpl/default-en/homes/widget/groups_widget.tpl
@@ -23,12 +23,12 @@ You are not a member of any Groups</div>
 <div class="groups-list-container">
 <ul class="groups-list">
 
+{% autoescape 'html' %}
 {% for group in groupsList %}
 <li title="{{ group.getName() }}" id="groups-list-{{ sticker.getId() }}-{{ group.getId() }}">
 		<div class="groups-list-icon"><a href="{{ group.generateClickLink() }}"><img src="{{ site.sitePath }}/habbo-imaging/badge/{{ group.getBadge() }}.gif"/></a></div>
 		<div class="groups-list-open"></div>
 		<h4>
-		{% autoescape 'html' %}
 		<a href="{{ group.generateClickLink() }}">{{ group.getName() }}</a>
 				</h4>
 		<p>
@@ -47,9 +47,9 @@ You are not a member of any Groups</div>
 		{% endif %}
 		</p>
 		<div class="clear"></div>
-		{% endautoescape %}
 	</li>
 {% endfor %}
+{% endautoescape %}
 
 </ul></div>
 		{% endif %}

--- a/tools/www-tpl/default-en/housekeeping/dashboard.tpl
+++ b/tools/www-tpl/default-en/housekeeping/dashboard.tpl
@@ -91,7 +91,9 @@
                   <td><a href="{{ site.sitePath }}/{{ site.housekeepingPath }}/users/edit?id={{ player.id }}">{{ player.name }}</a> - <a href="{{ site.sitePath }}/{{ site.housekeepingPath }}/transaction/lookup?searchQuery={{ player.getName() }}">Transactons</a></td>
 				  <td>{{ player.email }}</td>
 				  <td><img src="{{ site.sitePath }}/habbo-imaging/avatarimage?figure={{ player.figure }}&size=s"></td>
+									{% autoescape 'html' %}
                   <td>{{ player.motto }}</td>
+				 					{% endautoescape %}
                   <td>{{ player.credits }}</td>
                   <td>{{ player.pixels }}</td>
 				  <td>{{ player.formatLastOnline("dd-MM-yyyy HH:mm:ss") }}</td>

--- a/tools/www-tpl/default-en/housekeeping/users_edit.tpl
+++ b/tools/www-tpl/default-en/housekeeping/users_edit.tpl
@@ -4,6 +4,7 @@
      <h1 class="mt-4">Edit User</h1>
 		{% include "housekeeping/base/alert.tpl" %}
 		<p>Here you can edit user details.</p>
+		{% autoescape 'html' %}
 		<form class="table-responsive col-md-4" method="post">
 			<div class="form-group">
 				<label>Username:</label>
@@ -34,6 +35,7 @@
 				<button type="submit" class="btn btn-info">Save Details</button>
 			</div>
 		</form>
+		{% endautoescape %}
       </div>
     </div>
   </div>


### PR DESCRIPTION
This PR patches several xss vulnerabilities I found on a live instance of HavanaR39, but could be reproduced upstream.

![image](https://github.com/Quackster/Havana/assets/647632/46e50acb-98ae-461b-bfed-5f1902840f35)
![image](https://github.com/Quackster/Havana/assets/647632/1291c2f7-e056-4546-b5c1-5ae928a02279)
![image](https://github.com/Quackster/Havana/assets/647632/de1b4403-2488-4f4e-b546-8a79847cf228)
![image](https://github.com/Quackster/Havana/assets/647632/88e3e43f-1b42-4bd5-b2b3-71fe606c9723)
![image](https://github.com/Quackster/Havana/assets/647632/544db233-8511-4472-a96a-787c0b2d43a0)

The first example runs code on page load as it preloads the players profiles.

There's another vulnerability on the tag search page on the "tag yourself" button, and 2 more in housekeeping using the players motto, one of which runs code directly upon login due to the list of players.

The only notable change is in the tag search, where I moved the HTML snippet from the pebble variable into the template, allowing the use of autoescape. `autoescape` also didn't seem to take care of the variable use inside of the onclick handler, so I've added a replace filter escaping them.