### PR TITLE
Fix chess board broadcast

### DIFF
--- a/Havana-Server/src/main/java/org/alexdev/havana/game/games/gamehalls/GameChess.java
+++ b/Havana-Server/src/main/java/org/alexdev/havana/game/games/gamehalls/GameChess.java
@@ -167,14 +167,17 @@ public class GameChess extends GamehallGame {
                 if (this.board.isDraw()) {
                     this.gameFinished = true;
                     this.showChat("The chess game has ended in a draw");
+                    this.broadcastMap();
                     return;
                 } else if (this.board.isStaleMate()) {
                     this.gameFinished = true;
                     this.showChat("The chess game has encountered a stalemate");
+                    this.broadcastMap();
                     return;
                 } else if (this.board.isMated()) {
                     this.gameFinished = true;
                     this.showChat(player.getDetails().getName() + " has won the chess game");
+                    this.broadcastMap();
                     return;
                 }
 


### PR DESCRIPTION
Fixes #44.

By broadcasting the board only at the end of the `if (MOVEPIECE)`, the broadcast is prevented from happening when the game ends and the method returns before the broadcast. This causes the opposite player to not see the game ending move.

To fix this, broadcasts were added before the game ending returns.

You could technically add only once it inside the `if (isLegalMove)`, but it would duplicate broadcasts for all legal moves.