### PR TITLE
Run migrations while setting up MariaDB in Docker Compose

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -53,6 +53,9 @@ services:
     volumes:
       - data:/var/lib/mysql
       - ./tools/havana.sql:/docker-entrypoint-initdb.d/havana.sql
+      - ./tools/migrations/update.1.1.sql:/docker-entrypoint-initdb.d/update.1.1.sql
+      - ./tools/migrations/update.1.2.sql:/docker-entrypoint-initdb.d/update.1.2.sql
+      - ./tools/migrations/update.1.3.sql:/docker-entrypoint-initdb.d/update.1.3.sql
     healthcheck:
       test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
       start_period: 10s


### PR DESCRIPTION
These are required (see #58) so you would need to run these anyway while setting up the database. Since initdb is only run when the database is first initialized, we might as well run the migrations to save another manual setup step.