### PR TITLE
Fix missing web templates and static assets when building with Dockerfile-Web

### DIFF
--- a/Dockerfile-Web
+++ b/Dockerfile-Web
@@ -18,6 +18,10 @@ COPY --from=builder /sources/Havana-Web/build/libs/Havana-Web-unspecified.jar /h
 # Copy figuredata.xml
 COPY ./tools/figuredata.xml /havana-web/
 
+# Copy web templates and static assets
+COPY ./tools/www-tpl /havana-web/tools/www-tpl
+COPY ./tools/www /havana-web/tools/www
+
 # Copy entrypoint script
 COPY ./tools/docker/web-entrypoint.sh /havana-web/run.sh
 RUN chmod +x /havana-web/run.sh


### PR DESCRIPTION
## Summary

- Add COPY instructions for `tools/www-tpl` and `tools/www` to `Dockerfile-Web`.

These directories are required at runtime but were never copied into the container image. `Dockerfile-Web` only copied the JAR, `figuredata.xml`, and the entrypoint script, but not the templates (`tools/www-tpl/`) or static assets (`tools/www/`) directories. This behavior was causing a container crash on startup, with an infinite recursion:

```
havana-web-1     | 2026-01-28T10:22:28.478 ERROR [ErrorLogger] - Error occurred: 
havana-web-1     | java.lang.Exception: The template view overrides/default does not exist!
havana-web-1     | The path: /havana-web/tools/www-tpl/default-en/overrides/default.tpl
havana-web-1     |      at org.alexdev.http.template.TwigTemplate.start(TwigTemplate.java:63)
havana-web-1     |      at org.alexdev.duckhttpd.server.connection.WebConnection.template(WebConnection.java:164)
havana-web-1     |      at org.alexdev.http.server.ServerResponses.getErrorResponse(ServerResponses.java:27)
havana-web-1     |      at org.alexdev.http.template.TwigTemplate.start(TwigTemplate.java:83)
havana-web-1     |      at org.alexdev.duckhttpd.server.connection.WebConnection.template(WebConnection.java:164)
havana-web-1     |      at org.alexdev.http.server.ServerResponses.getErrorResponse(ServerResponses.java:27)
havana-web-1     |      at org.alexdev.http.template.TwigTemplate.start(TwigTemplate.java:83)
```
